### PR TITLE
Add secret parameters

### DIFF
--- a/lib/fluent/plugin/out_tumblr.rb
+++ b/lib/fluent/plugin/out_tumblr.rb
@@ -12,10 +12,10 @@ module Fluent
       super
     end
 
-    config_param :consumer_key, :string
-    config_param :consumer_secret, :string
-    config_param :oauth_token, :string
-    config_param :oauth_token_secret, :string
+    config_param :consumer_key, :string, :secret => true
+    config_param :consumer_secret, :string, :secret => true
+    config_param :oauth_token, :string, :secret => true
+    config_param :oauth_token_secret, :string, :secret => true
 
     config_param :tumblr_url, :string
     config_param :tags_template, :string


### PR DESCRIPTION
In fluentd 0.12.11 or later supports secret parameters feature.
This feature works in log as below:

``` log
  <match tumblr.*>
    type tumblr
    consumer_key xxxxxx
    consumer_secret xxxxxx
    oauth_token xxxxxx
    oauth_token_secret xxxxxx
    tumblr_url YOUR_TUMBLR_URL
    tags_template TAG_<%= record['tag'] %>
    caption_template <%= record['message'] %>
    link_key url
    image_key raw_image
    post_type picture
    base64encoded true
  </match>
</ROOT>
```
